### PR TITLE
constify all payload paths

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -1029,7 +1029,7 @@ fec_scheme   packetizer_get_fec1       (packetizer _p);
 //  _msg    :   input message (uncoded bytes)
 //  _pkt    :   encoded output message
 void packetizer_encode(packetizer _p,
-                       unsigned char * _msg,
+                       const unsigned char * _msg,
                        unsigned char * _pkt);
 
 // packetizer_decode()
@@ -3436,7 +3436,7 @@ unsigned int qpacketmodem_get_modscheme(qpacketmodem _q);
 //  _payload    :   unencoded payload bytes
 //  _syms       :   encoded but un-modulated payload symbol indices
 void qpacketmodem_encode_syms(qpacketmodem    _q,
-                              unsigned char * _payload,
+                              const unsigned char * _payload,
                               unsigned char * _syms);
 
 // decode packet from demodulated frame symbol indices (hard-decision decoding)
@@ -3460,7 +3460,7 @@ int qpacketmodem_decode_bits(qpacketmodem    _q,
 //  _payload    :   unencoded payload bytes
 //  _frame      :   encoded/modulated payload symbols
 void qpacketmodem_encode(qpacketmodem           _q,
-                         unsigned char *        _payload,
+                         const unsigned char *        _payload,
                          liquid_float_complex * _frame);
 
 // decode packet from modulated frame samples, returning flag if CRC passed

--- a/src/fec/src/packetizer.c
+++ b/src/fec/src/packetizer.c
@@ -245,7 +245,7 @@ fec_scheme packetizer_get_fec1(packetizer _p)
 //  _msg    :   input message (uncoded bytes)
 //  _pkt    :   encoded output message
 void packetizer_encode(packetizer _p,
-                       unsigned char * _msg,
+                       const unsigned char * _msg,
                        unsigned char * _pkt)
 {
     unsigned int i;

--- a/src/framing/src/gmskframegen.c
+++ b/src/framing/src/gmskframegen.c
@@ -36,7 +36,7 @@
 #define DEBUG_GMSKFRAMEGEN    0
 
 // gmskframegen
-void gmskframegen_encode_header( gmskframegen _q, unsigned char * _header);
+void gmskframegen_encode_header( gmskframegen _q, const unsigned char * _header);
 void gmskframegen_write_preamble(gmskframegen _q, float complex * _y);
 void gmskframegen_write_header(  gmskframegen _q, float complex * _y);
 void gmskframegen_write_payload( gmskframegen _q, float complex * _y);
@@ -316,7 +316,7 @@ int gmskframegen_write_samples(gmskframegen _q,
 //
 
 void gmskframegen_encode_header(gmskframegen    _q,
-                                unsigned char * _header)
+                                const unsigned char * _header)
 {
     // first 'n' bytes user data
     memmove(_q->header_dec, _header, GMSKFRAME_H_USER);

--- a/src/framing/src/qpacketmodem.c
+++ b/src/framing/src/qpacketmodem.c
@@ -193,7 +193,7 @@ unsigned int qpacketmodem_get_modscheme(qpacketmodem _q)
 //  _payload    :   unencoded payload bytes
 //  _syms       :   encoded but un-modulated payload symbol indices
 void qpacketmodem_encode_syms(qpacketmodem    _q,
-                              unsigned char * _payload,
+                              const unsigned char * _payload,
                               unsigned char * _syms)
 {
     // encode payload
@@ -249,7 +249,7 @@ int qpacketmodem_decode_bits(qpacketmodem    _q,
 //  _payload    :   unencoded payload bytes
 //  _frame      :   encoded/modulated payload symbols
 void qpacketmodem_encode(qpacketmodem    _q,
-                         unsigned char * _payload,
+                         const unsigned char * _payload,
                          float complex * _frame)
 {
     // encode payload symbols into internal buffer


### PR DESCRIPTION
this finishes off the const changes from before, silencing all const warnings on user payloads